### PR TITLE
Add move function for Doodlebug, fixed other files to reflect changes

### DIFF
--- a/Critter.cpp
+++ b/Critter.cpp
@@ -22,6 +22,7 @@ Critter::Critter()
     //this->y_pos = y_pos;
     this->age = 0;
     this->symbol = ' ';
+    this->moveSuccess = 0;
 }
 
 //Set functions
@@ -61,10 +62,9 @@ int Critter::getY_pos()
     return y_pos;
 }
 
-bool Critter::move(Critter ***boardIn)
+void Critter::move(Critter *** &boardIn)
 {
     std::cout << "in critter move" << std::endl;
-    return true;
 }
 
 /******************************************************************************
@@ -75,37 +75,44 @@ bool Critter::move(Critter ***boardIn)
  **              It returns false if the move does not go out of bounds, and
  **              true if the move would result in going out of bounds.
  ******************************************************************************/
-bool Critter::moveOutOfBounce(int direction)
+bool Critter::checkBounds(int new_x, int new_y)
 {
     bool outOfBounce = true;
-    if (direction == 0) //Direction North (move row up 1)
+
+    if(new_x < 0 || new_x > 19) //TODO NEED TO MAKE ROWS AND COLUMNS PART OF CRITTER CONSTRUCTOR TO USE ROWS AND COLUMNS CRITERIA FOR BOUNDS FUNCTION
+      outOfBounce = false;
+
+    if(new_y < 0 || new_y > 19)
+      outOfBounce = false;
+
+ /*   if (direction == 0) //Direction North (move row down 1)
     {
-        if (this->x_pos -1 > 0)
+        if (this->x_pos -1 < 0)
         {
             outOfBounce = false;
         }
     }
-    else if (direction == 1) //Direction South (move row up 1)
+    else if (direction == 1) //Direction East (move col up 1)
     {
-        if (this->x_pos + 1 <rows)
+        if (this->y_pos + 1 > 19)
         {
             outOfBounce =  false;
         }
     }
-    else if (direction == 2) //Direction East (move column up 1)
+    else if (direction == 2) //Direction South (move row up 1)
     {
-        if (this->y_pos + 1 < columns)
+        if (this->x_pos + 1 > 19)
         {
             outOfBounce = false;
         }
     }
     else //Direction = 3, Direction West (move column down 1)
     {
-        if (this->y_pos -1 > 0)
+        if (this->y_pos -1 < 0)
         {
             outOfBounce = false;
         }
-    }
+    }*/
     return outOfBounce;
 }
 
@@ -126,6 +133,15 @@ void Critter::print_board(Critter *** board, int rows, int cols)
   }
 }
 
+void Critter::resetMoveSuccess()
+{
+   this->moveSuccess = 0;
+}
+
+int Critter::getMoveSuccess()
+{
+   return this->moveSuccess;
+}
 /*helper function for breed testing
 void Critter::setAge(int ageIn)
 {

--- a/Critter.hpp
+++ b/Critter.hpp
@@ -20,12 +20,13 @@ class Critter
         char symbol;
         int rows;
         int columns;
+        int moveSuccess;
 
     public:
         Critter();
         virtual ~Critter(){};
-        virtual bool move(Critter ***);
-        virtual void breed(Critter ***&){};
+        virtual void move( Critter ***&);
+        virtual void breed(const Critter ***&){};
 
         char getSymbol();
         int getX_pos();
@@ -36,7 +37,9 @@ class Critter
         void print_board(Critter *** board, int rows, int cols);
         void setRows(int);
         void setColumns(int);
-        bool moveOutOfBounce(int);
+        bool checkBounds(int , int);
+	void resetMoveSuccess();
+        int getMoveSuccess();
         //helper function for breed testing
         //virtual void setAge(int ageIn);
 };

--- a/Doodlebug.cpp
+++ b/Doodlebug.cpp
@@ -14,22 +14,194 @@ Doodlebug::Doodlebug(int x_pos, int y_pos):Critter()
    this->age = 0;
    this->hunger = 0;
    this->symbol = 'X';
+   this->moveSuccess = 0;
 }
 
-bool Doodlebug::move(Critter ***boardIn)
+void Doodlebug::move(Critter*** &boardIn)
 {
-   cout << "in doodlemove" << endl;
-   return true;
+   int random = randIntRange(0,3);
+   bool antNear = false;
+   bool inBounds = false;
+   bool cellFree = false;
+
+   int new_x, new_y;
+   int attempts = 0;
+
+   //check if ant is in an adjacent cell
+   switch (random) 
+   {
+      case 0: new_x = this->x_pos - 1;
+              new_y = this->y_pos;
+              inBounds = checkBounds(new_x, new_y);
+              if(inBounds && boardIn[new_x][new_y] != NULL && boardIn[new_x][new_y]->getSymbol() == 'O')
+              {
+                 antNear = true;   
+	         break;
+              }
+              else if(attempts >= 4)
+                 break;
+              else
+              {
+                 attempts++; 
+                 random = 1;
+              }
+      case 1: new_x = this->x_pos;
+              new_y = this->y_pos + 1;
+              inBounds = checkBounds(new_x, new_y);
+              if(inBounds && boardIn[new_x][new_y] != NULL && boardIn[new_x][new_y]->getSymbol() == 'O')
+              {
+                 antNear = true;
+	         break;
+              }
+              else if(attempts >= 4)
+                 break;
+              else 
+              {
+                 attempts++; 
+                 random = 2;
+              }
+      case 2: new_x = this->x_pos + 1;
+              new_y = this->y_pos;
+              inBounds = checkBounds(new_x, new_y);
+              if(inBounds && boardIn[new_x][new_y] != NULL && boardIn[new_x][new_y]->getSymbol() == 'O')
+              {
+                 antNear = true;
+	         break;
+              }
+              else if(attempts >= 4)
+                 break;
+              else
+              {
+                 attempts++; 
+                 random = 3;
+              }
+      case 3: new_x = this->x_pos;
+              new_y = this->y_pos - 1;
+              inBounds = checkBounds(new_x, new_y);
+              if(inBounds && boardIn[new_x][new_y] != NULL && boardIn[new_x][new_y]->getSymbol() == 'O')
+              {
+                 antNear = true;
+	         break;
+              }
+              else if(attempts >= 4)
+                 break;
+              else
+              {
+                 attempts++;
+                 random = 0;
+              }
+   }
+
+   if(antNear == true)
+   {
+      delete boardIn[new_x][new_y]; //delete Ant at the new x,y position
+      //set pointer at new x,y position equal to the Doodlebug point that is moving
+      boardIn[new_x][new_y] = boardIn[this->x_pos][this->y_pos];      
+      //reset the pointer at the old position to NULL to signify that the space is empty
+      boardIn[this->x_pos][this->y_pos] = NULL;
+      //update x and y position for the Doodlebug
+      this->x_pos = new_x;
+      this->y_pos = new_y;
+      this->hunger = 0;
+      this->moveSuccess = 1;
+   }
+ 
+   else //if antNear == false
+   {
+      attempts = 0;
+      this->hunger += 1;
+      random = randIntRange(0,3);
+      switch (random) 
+      {
+         case 0: new_x = this->x_pos - 1;
+                 new_y = this->y_pos;
+                 inBounds = checkBounds(new_x, new_y);
+                 if(inBounds && boardIn[new_x][new_y] == NULL)
+                 {
+                    cellFree = true;   
+	            break;
+                 }
+                 else if(attempts >= 4)
+                    break;
+                 else
+                 {  
+                    attempts++;
+                    random = 1;
+                 }
+         case 1: new_x = this->x_pos;
+                 new_y = this->y_pos + 1;
+                 inBounds = checkBounds(new_x, new_y);
+                 if(inBounds && boardIn[new_x][new_y] == NULL)
+                 {
+                    cellFree = true;
+      	            break;
+                 }
+                 else if(attempts >= 4)
+                    break;
+                 else
+                 {
+                    attempts++;
+                    random = 2;
+                 }  
+         case 2: new_x = this->x_pos + 1;
+                 new_y = this->y_pos;
+                 inBounds = checkBounds(new_x, new_y);
+                 if(inBounds && boardIn[new_x][new_y] == NULL)
+                 {
+                    cellFree = true;
+	            break;
+                 }
+                 else if(attempts >= 4)
+                    break;
+                 else
+                 {
+                    attempts++;
+                    random = 3;
+                 }
+         case 3: new_x = this->x_pos;
+                 new_y = this->y_pos - 1;
+                 inBounds = checkBounds(new_x, new_y);
+                 if(inBounds && boardIn[new_x][new_y] == NULL)
+                 {
+                    cellFree = true;
+	            break;
+                 }
+                 else if(attempts >= 4)
+                    break;
+                 else
+                 {
+                    attempts++;
+                    random = 0;
+                 }
+      }
+
+      if(cellFree == true)
+      {
+         delete  boardIn[new_x][new_y];
+         boardIn[new_x][new_y] = boardIn[this->x_pos][this->y_pos];
+         boardIn[this->x_pos][this->y_pos] = NULL;
+         this->x_pos = new_x;
+         this->y_pos = new_y;
+	 this->moveSuccess = 1;
+      }
+
+      else
+      {
+         this->moveSuccess = 1;
+         return;
+      }
+   }
 }
 
-void Doodlebug::breed(Critter *** &boardIn)
+
+void Doodlebug::breed(const Critter *** &boardIn)
 {
    bool cellFree = false;
    int new_x, new_y;
    int direction = randIntRange(0,3);
    int randIterator = 0;
    //check that adjacent cell is free, i.e. printSymbol() of the object of that cell returns ' '
-   if(age ==8)
+   if(this->age == 8)
    {
      while(cellFree == false && randIterator != 3)
      {

--- a/Doodlebug.hpp
+++ b/Doodlebug.hpp
@@ -16,8 +16,8 @@ class Doodlebug : public Critter
       Doodlebug(int, int);
       ~Doodlebug(){};
 
-      bool move(Critter ***);
-      void breed(Critter *** &);
+      void move(Critter *** &);
+      void breed(const Critter *** &);
       //helper function for setAge
       void setAge(int ageIn);
 };

--- a/main.cpp
+++ b/main.cpp
@@ -89,7 +89,7 @@ int main()
     }
 
     //set board spaces to null
-    board = new Critter**[size_y];
+    /*board = new Critter**[size_y];
     for(int i = 0; i < size_y; i++)
     {
       board[i] = new Critter*[size_x];
@@ -97,7 +97,17 @@ int main()
       {
         board[i][j] = NULL;
       }
-    }
+    }*/
+    board = new Critter**[size_y];
+        for(int i = 0; i < size_y; i++)
+         {
+            board[i] = new Critter*[size_x];
+            
+            for(int j = 0; j < size_x; j++)
+            {
+               board[i][j] = NULL;
+            }
+        }
 
     int doodCount = 0;
     int antCount = 0;
@@ -154,9 +164,38 @@ int main()
       cout << "\n";
     }
     cout << "\n";
+    
+    //test moving doodlebug
+    for(int i=0; i<size_y; i++)
+    {
+      for(int j=0; j<size_x; j++)
+      {
+          if(board[i][j] != NULL && board[i][j]->getSymbol() == 'X')
+          {
+            if(board[i][j]->getMoveSuccess() == 0)
+            {
+              cout << "Attempting to move from row " << i;
+              cout << " and col " << j << "\n";
+                 board[i][j]->move(board);
+            }
+          }
+      }
+    }
+    //reset move success for next round, 
+    for(int i=0; i<size_y; i++)
+    {
+      for(int j=0; j<size_x; j++)
+      {
+          if(board[i][j] != NULL)
+            {
+              board[i][j]->resetMoveSuccess();
+            }
+      }
+    }
+
 
     //call breed - this should be a function outside of main that just gets called
-    for(int i=0; i<size_y; i++)
+/*    for(int i=0; i<size_y; i++)
     {
       for(int j=0; j<size_x; j++)
       {
@@ -168,7 +207,7 @@ int main()
             }
       }
     }
-
+*/
     cout << "\n" << "Printing board again" << "\n\n";
 
     //print board again to see if breed worked


### PR DESCRIPTION
Needed to add a flag, moveSuccessful, to the Critter class so that when an object moves to the east we don't keep asking it to move as we loop through the critter array. Move function only exists in Doodlebug right now, will move to ant on next update. Updated the bounds checking function in Critter to just check that the rows and columns added to them are less than the board rows and columns, had trouble accessing board rows  and columns so they are hard coded to 19 right now. Will need to add a loop to initialize the board rows and columns after the board is dynamically allocated.